### PR TITLE
Enable `go mod tidy` for renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,10 @@
   "extends": [
     "config:base"
   ],
-  "gomod": {
-    "postUpdateOptions": ["gomodTidy"]
-  }
+  "labels": [
+    "dependency"
+  ],
+  "postUpdateOptions": [
+    "gomodTidy"
+  ]
 }


### PR DESCRIPTION
Currently renovate PRs fail because of go.sum up-to-date check

## Summary



<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [ ] Keep pull requests small so they can be easily reviewed.
- [ ] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [ ] Update the documentation.
- [ ] Update tests.
- [ ] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
