### PR TITLE
Fix Keycloak session leak

### DIFF
--- a/internal/pkg/keycloak/client.go
+++ b/internal/pkg/keycloak/client.go
@@ -37,6 +37,8 @@ func (g *gocloakClient) GetUsers(ctx context.Context, realm string, params goclo
 	if err != nil {
 		return nil, fmt.Errorf("failed binding to keycloak: %w", err)
 	}
+	// `admin-cli` is the magic client used when authenticating to the admin API
+	defer g.client.LogoutPublicClient(ctx, "admin-cli", g.loginRealm, token.AccessToken, token.RefreshToken)
 
 	return g.client.GetUsers(ctx, token.AccessToken, realm, params)
 }


### PR DESCRIPTION
The sessions opened by `Login` seem to expire after an hour or so, but we still always have a lot of open sessions if we don't close them.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog


<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
